### PR TITLE
Don't set instance for prod deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,10 +9,9 @@ on:
 
 # Set values as organization or repository secrets
 env:
-  VESPA_CLI_API_KEY: ${{ secrets.VESPA_TEAM_VESPACLOUD_DOCSEARCH_API_KEY }}
+  VESPA_CLI_API_KEY: ${{ secrets.API_KEY }}
   TENANT_NAME:       ${{ secrets.TENANT_NAME }}
   APP_NAME:          ${{ secrets.APP_NAME }}
-  INSTANCE_NAME:     ${{ secrets.INSTANCE_NAME }}
 
 defaults:
   run:
@@ -35,5 +34,5 @@ jobs:
     - name: Deploy to Vespa Cloud
       run: |
         ./vespa config set target cloud
-        ./vespa config set application "$TENANT_NAME.$APP_NAME.$INSTANCE_NAME"
+        ./vespa config set application "$TENANT_NAME.$APP_NAME"
         ./vespa prod deploy


### PR DESCRIPTION
- it is confusing. instance is read from deployment.xml, and if not set there, "default" is used

Note: the GH action will still fail until we set the secrets